### PR TITLE
Add a legend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.dot
 *.svg
 output
+
+### IDE files
+/.idea/

--- a/src/graphviz.rs
+++ b/src/graphviz.rs
@@ -93,12 +93,18 @@ fn write_group_label(group: &Group, output: &mut dyn Write) {
     let label = group.label.as_ref().unwrap_or(&group.name);
     let label = escape(label);
     let group_href = attribute_str("href", &group.href, "");
+    let header_color = group
+        .header_color
+        .as_ref()
+        .map(String::as_str)
+        .unwrap_or("darkgoldenrod");
 
     writeln!(
         output,
-        r#"    <tr><td bgcolor="darkgoldenrod" port="all" colspan="2"{group_href}>{label}</td></tr>"#,
+        r#"    <tr><td bgcolor="{header_color}" port="all" colspan="2"{group_href}>{label}</td></tr>"#,
         group_href = group_href,
         label = label,
+        header_color = header_color
     )?;
 
     for item in &group.items {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -24,6 +24,7 @@ pub(crate) struct Group {
     pub(crate) width: Option<f64>,
     pub(crate) status: Option<Status>,
     pub(crate) href: Option<String>,
+    pub(crate) header_color: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/tree-data/example.toml
+++ b/tree-data/example.toml
@@ -1,4 +1,15 @@
 [[group]]
+name = "legend"
+label = "Legend"
+header_color = "red"
+items = [
+  { label = "Unassigned", status = "Unassigned" },
+  { label = "Blocked", status = "Blocked" },
+  { label = "Assigned / In-progress", status = "Assigned" },
+  { label = "Complete", status = "Complete" }
+]
+
+[[group]]
 name = "align-rustc-predicate"
 label = "Align rustc predicates with chalk predicates"
 items = [


### PR DESCRIPTION
Closes #3 (though doesn't make any other visual adjustments as mentioned in the issue, probably better to make a separate issue).

The legend is added by making a new group with a custom header color. More can be done to make it stand out, but I have not found a way to pin the legend to, say, the top left corner.

I also added an entry in the gitignore for IntelliJ editors.

![image](https://user-images.githubusercontent.com/4417660/81945964-c63d6200-95cc-11ea-82da-105f454e1a5b.png)