### PR TITLE
Speed up build time by building proc macros without optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ serde_derive = "1.0"
 svg = "0.5.12"
 toml = "0.5.1"
 htmlescape = "0.3.1"
+
+[profile.release.build-override]
+opt-level = 0


### PR DESCRIPTION
Don't spend build time optimizing build-time-only crates. Crates used
exclusively at build time, such as proc-macro crates and their
dependencies, don't benefit substantially from optimization; they take
far longer to optimize than time saved when running them during the
build. No machine code from these crates will appear in the final
compiled binary.

Use the new profile-overrides mechanism in Rust 1.41
(https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) to
build such crates with opt-level 0.

Before:

    Finished release [optimized] target(s) in 1m 57s

After:

    Finished release [optimized] target(s) in 45.46s